### PR TITLE
fix(driver): fix datetimediff function

### DIFF
--- a/src/metabase/driver/starrocks.clj
+++ b/src/metabase/driver/starrocks.clj
@@ -41,6 +41,7 @@
                               :connection/multiple-databases   true
                               :metadata/key-constraints        false
                               :now                             true
+                              :datetime-diff                   true
                               :temporal-extract                true
                               :date-arithmetics                true
                               :advanced-math-expressions       true}]
@@ -303,28 +304,28 @@
   [:date_add hsql-form [:interval amount (keyword (name unit))]])
 
 (defmethod sql.qp/datetime-diff [:starrocks :year]
-  [_ _ unit x y]
-  [:timestampdiff (keyword (name unit)) x y])
+  [_ unit x y]
+  [:timestampdiff [:raw (name unit)] x y])
 
 (defmethod sql.qp/datetime-diff [:starrocks :month]
-  [_ _ unit x y]
-  [:timestampdiff (keyword (name unit)) x y])
+  [_ unit x y]
+  [:timestampdiff [:raw (name unit)] x y])
 
 (defmethod sql.qp/datetime-diff [:starrocks :day]
-  [_ _ unit x y]
+  [_ unit x y]
   [:datediff y x])
 
 (defmethod sql.qp/datetime-diff [:starrocks :hour]
-  [_ _ unit x y]
-  [:timestampdiff (keyword (name unit)) x y])
+  [_ unit x y]
+  [:timestampdiff [:raw (name unit)] x y])
 
 (defmethod sql.qp/datetime-diff [:starrocks :minute]
-  [_ _ unit x y]
-  [:timestampdiff (keyword (name unit)) x y])
+  [_ unit x y]
+  [:timestampdiff [:raw (name unit)] x y])
 
 (defmethod sql.qp/datetime-diff [:starrocks :second]
-  [_ _ unit x y]
-  [:timestampdiff (keyword (name unit)) x y])
+  [_ unit x y]
+  [:timestampdiff [:raw (name unit)] x y])
 
 (defmethod sql.qp/cast-temporal-string [:starrocks :Coercion/ISO8601->DateTime]
   [_ _ expr]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches StarRocks query SQL generation for `datetime-diff`, which can change results or break queries if the unit formatting/signature is still mismatched with upstream expectations.
> 
> **Overview**
> Enables the `:datetime-diff` feature for the StarRocks driver and fixes its `sql.qp/datetime-diff` implementations.
> 
> Updates the method arity to match the expected dispatcher and changes `timestampdiff` unit rendering from a keyword to a raw SQL fragment (keeping `:day` using `datediff`), preventing invalid SQL from being produced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 671514d22667fd1401a7985b2e3a698340445f50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->