### PR TITLE
feat(driver): opt-in SSL with VERIFY_CA / VERIFY_IDENTITY / REQUIRED

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ Then restart Metabase to load the driver.
 | Database | Database within catalog (optional) | `my_database` |
 | Username | StarRocks user | `admin` |
 | Password | User password | `••••••••` |
+| Use a secure connection (SSL) | Encrypt the MySQL protocol connection | Enabled when FE requires SSL |
+| Server SSL certificate chain | CA / server PEM chain for trust | Required when FE uses a private or self-signed CA |
+
+### SSL
+
+StarRocks supports SSL on the MySQL protocol port (default `9030`) starting from **v3.4.1**. Configure the FE node first — see the [StarRocks SSL documentation](https://docs.starrocks.io/docs/administration/user_privs/ssl_authentication/) (`ssl_keystore_location`, `ssl_keystore_password`, `ssl_key_password` in `fe.conf`).
+
+1. Enable **Use a secure connection (SSL)** in the database connection form (off by default; no SSL settings apply when unchecked).
+2. Choose **SSL mode** (three levels, only shown when SSL is enabled):
+   - **VERIFY_CA** (default): encrypt + verify the certificate chain (paste CA PEM for private / Aliyun CAs).
+   - **VERIFY_IDENTITY**: encrypt + verify certificate and hostname (public CA in JVM trust store).
+   - **REQUIRED**: encrypt only, no certificate validation (only if your security policy allows).
+3. Optionally paste the CA / certificate chain (PEM) into **Server SSL certificate chain**.
+4. **Additional JDBC options** can still override `sslMode` when SSL is enabled. With SSL off, SSL-related keys in additional options are ignored.
+
+> **Note**: StarRocks v3.2+ is required for catalog support; SSL on the MySQL port requires v3.4.1+.
 
 ### Catalog Examples
 
@@ -143,6 +159,13 @@ This triggers a workflow that builds the JAR and creates a GitHub release with t
 - Verify the catalog name is correct
 - Check that the user has `SELECT` privileges on the tables
 - Try leaving the Database field empty to scan all databases
+
+### SSL Connection Failed
+
+- StarRocks FE must have SSL configured in `fe.conf` (requires StarRocks v3.4.1+)
+- Enable **Use a secure connection (SSL)** when the FE requires encrypted connections
+- **PKIX / certificate_unknown**: paste the FE CA or full certificate chain (PEM) into **Server SSL certificate chain**, or import that CA into the Metabase JVM truststore
+- If hostname verification fails with a valid CA, try `sslMode=VERIFY_CA` in additional JDBC options (verifies the chain but is less strict on hostname than `VERIFY_IDENTITY`)
 
 ### Sync Errors
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,8 +2,8 @@
 
  :deps
  {org.clojure/clojure {:mvn/version "1.11.1"}
-  ;; MariaDB JDBC driver (MySQL compatible, used for StarRocks)
-  org.mariadb.jdbc/mariadb-java-client {:mvn/version "3.3.2"}}
+  ;; MySQL Connector/J — recommended by StarRocks for MySQL-protocol SSL (useSSL + verifyServerCertificate)
+  com.mysql/mysql-connector-j {:mvn/version "8.0.33"}}
 
  :aliases
  {:build

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase StarRocks Driver
-  version: 1.0.0
+  version: 1.1.0
   description: StarRocks driver for Metabase with multi-catalog support.
 
 driver:
@@ -26,6 +26,26 @@ driver:
       helper-text: "Specific database within the catalog. Leave empty to see all databases."
     - user
     - password
+    - ssl
+    - name: ssl-mode
+      display-name: SSL mode
+      type: select
+      default: VERIFY_CA
+      helper-text: "VERIFY_CA or VERIFY_IDENTITY validate the server certificate; REQUIRED encrypts only."
+      options:
+        - name: Verify CA (encrypt + verify certificate chain)
+          value: VERIFY_CA
+        - name: Verify identity (encrypt + verify certificate + hostname)
+          value: VERIFY_IDENTITY
+        - name: Required (encrypt only)
+          value: REQUIRED
+      visible-if:
+        ssl: true
+    - name: ssl-cert
+      display-name: Server SSL certificate chain
+      helper-text: "PEM CA or certificate chain. Recommended for VERIFY_CA / private or Aliyun CAs."
+      visible-if:
+        ssl: true
     - ssh-tunnel
     - advanced-options-start
     - merge:
@@ -37,4 +57,4 @@ init:
   - step: load-namespace
     namespace: metabase.driver.starrocks
   - step: register-jdbc-driver
-    class: org.mariadb.jdbc.Driver
+    class: com.mysql.cj.jdbc.Driver

--- a/src/metabase/driver/starrocks.clj
+++ b/src/metabase/driver/starrocks.clj
@@ -17,7 +17,11 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.util.log :as log])
   (:import
-   (java.sql Connection ResultSet)))
+   (java.io ByteArrayInputStream FileOutputStream)
+   (java.security KeyStore)
+   (java.security.cert Certificate CertificateFactory)
+   (java.sql Connection ResultSet)
+   (java.util Base64)))
 
 (set! *warn-on-reflection* true)
 
@@ -51,8 +55,123 @@
 ;;; |                                          Connection Details                                                     |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defn- additional-options->map
+  "Parse `additional-options` string (`key=value&...`) into a map with string keys."
+  [additional-options]
+  (when (and additional-options (not (str/blank? additional-options)))
+    (into {}
+          (for [pair (str/split additional-options #"&")
+                :let [pair (str/trim pair)]
+                :when (not (str/blank? pair))]
+            (let [[k v] (str/split pair #"=" 2)]
+              [(str/trim k) (or v "")])))))
+
+(def ^:private ssl-jdbc-property-keys
+  "JDBC properties that only apply when the user enables SSL in the connection form."
+  #{:useSSL :sslMode :requireSSL :verifyServerCertificate :trustServerCertificate
+    :trustCertificateKeyStoreUrl :trustCertificateKeyStoreType :trustCertificateKeyStorePassword
+    :clientCertificateKeyStoreUrl :clientCertificateKeyStoreType :clientCertificateKeyStorePassword
+    :enabledSslProtocolSuites :enabledSslCipherSuites})
+
+(defn- ssl-enabled?
+  "SSL is opt-in only: controlled by the Metabase \"Use a secure connection (SSL)\" checkbox."
+  [{:keys [ssl]}]
+  (boolean ssl))
+
+(defn- without-ssl-jdbc-keys
+  "Remove SSL-related keys so additional-options cannot enable SSL when the checkbox is off."
+  [opts-map]
+  (into {} (remove (fn [[k _]] (contains? ssl-jdbc-property-keys k)) opts-map)))
+
+(defn- valid-pem?
+  "True when `pem-content` looks like at least one PEM certificate block."
+  [pem-content]
+  (boolean
+   (and (not (str/blank? pem-content))
+        (re-find #"-----BEGIN CERTIFICATE-----" (str pem-content)))))
+
+(defn- parse-pem-certificates
+  "Parse one or more PEM X.509 certificates from `pem-content`."
+  ^"[Ljava.security.cert.Certificate;" [^String pem-content]
+  (let [^CertificateFactory cf (CertificateFactory/getInstance "X.509")
+        blocks                (re-seq #"-----BEGIN CERTIFICATE-----\s*([\s\S]*?)\s*-----END CERTIFICATE-----"
+                                    pem-content)]
+    (into-array Certificate
+                (mapcat (fn [[_b64-body b64-body]]
+                          (let [^String cleaned (str/replace b64-body #"\s" "")
+                                bytes           (.decode (Base64/getDecoder) cleaned)]
+                            (.generateCertificates cf (ByteArrayInputStream. bytes))))
+                        blocks))))
+
+(defn- jks-truststore-file-url
+  "Build a JKS truststore from PEM CA/certificate chain (works on all JDKs; avoids PEM KeyStore type)."
+  [^String pem-content]
+  (let [certs     (parse-pem-certificates pem-content)
+        ^KeyStore ks (KeyStore/getInstance (KeyStore/getDefaultType))]
+    (.load ks nil nil)
+    (dotimes [i (alength certs)]
+      (.setCertificateEntry ks (str "ca-" i) (aget certs i)))
+    (let [^java.io.File f (doto (java.io.File/createTempFile "starrocks-trust-" ".jks")
+                              (.deleteOnExit))]
+      (with-open [^FileOutputStream os (FileOutputStream. f)]
+        (.store ks os (char-array "")))
+      (str "file:" (.getAbsolutePath f)))))
+
+(defn- normalize-ssl-mode
+  "Normalize ssl-mode from the connection form (e.g. verify-identity -> VERIFY_IDENTITY)."
+  [mode]
+  (when-not (str/blank? mode)
+    (-> mode str/trim str/upper-case (str/replace #"-" "_"))))
+
+(defn- ssl-mode-verifies-certificate?
+  [ssl-mode]
+  (boolean (and ssl-mode (re-find #"VERIFY" ssl-mode))))
+
+(defn- default-ssl-mode
+  "Default sslMode when the form field is left empty."
+  [ssl-cert-pem]
+  (if ssl-cert-pem "VERIFY_CA" "VERIFY_IDENTITY"))
+
+(defn- ssl-jdbc-spec
+  "Build JDBC SSL options from the ssl-mode form field and optional PEM trust material.
+   Custom CA PEM is only applied for VERIFY_CA (JKS truststore). VERIFY_IDENTITY uses the JVM trust store
+   and also checks that the certificate hostname matches the connection host."
+  [ssl-cert-pem ssl-mode-from-form]
+  (let [ssl-mode       (or (normalize-ssl-mode ssl-mode-from-form)
+                           (default-ssl-mode ssl-cert-pem))
+        use-custom-ca? (and (= ssl-mode "VERIFY_CA")
+                            (valid-pem? ssl-cert-pem))]
+    (when (and (= ssl-mode "VERIFY_CA") ssl-cert-pem (not (valid-pem? ssl-cert-pem)))
+      (log/warn "StarRocks SSL: ssl-cert is set but does not contain a valid PEM certificate; using JVM truststore only."))
+    (cond-> {:useSSL "true" :sslMode ssl-mode}
+      (= ssl-mode "VERIFY_IDENTITY") (assoc :verifyServerCertificate "true")
+      use-custom-ca?
+      (assoc :trustCertificateKeyStoreType "JKS"
+             :trustCertificateKeyStoreUrl   (jks-truststore-file-url ssl-cert-pem)
+             :trustCertificateKeyStorePassword ""))))
+
+(defn- maybe-log-ssl-hint
+  "Log SSL configuration hints when verification is enabled."
+  [ssl? ssl-cert ssl-mode-from-form additional-options]
+  (when ssl?
+    (let [addl-opts-map   (additional-options->map additional-options)
+          ssl-cert?       (and ssl-cert (not (str/blank? (str ssl-cert))))
+          form-ssl-mode   (normalize-ssl-mode ssl-mode-from-form)
+          addl-ssl-mode   (some-> (get addl-opts-map "sslMode") normalize-ssl-mode)
+          effective-mode  (or addl-ssl-mode form-ssl-mode (default-ssl-mode (when ssl-cert? (str ssl-cert))))]
+      (when (= "false" (get addl-opts-map "verifyServerCertificate"))
+        (log/warn "StarRocks SSL: verifyServerCertificate=false disables certificate validation."))
+      (when (= "REQUIRED" effective-mode)
+        (log/warnf "StarRocks SSL: sslMode=REQUIRED encrypts but does not verify the server certificate."
+                   effective-mode))
+      (when (and (ssl-mode-verifies-certificate? effective-mode)
+                 (not ssl-cert?)
+                 (not (contains? addl-opts-map "trustCertificateKeyStoreUrl")))
+        (log/infof "StarRocks SSL: sslMode=%s with JVM truststore. Paste the server CA PEM chain into 'Server SSL certificate chain' if you see PKIX / certificate_unknown errors."
+                   effective-mode)))))
+
 (defmethod sql-jdbc.conn/connection-details->spec :starrocks
-  [_ {:keys [host port catalog dbname user password additional-options]
+  [_ {:keys [host port catalog dbname user password ssl ssl-mode ssl-cert additional-options]
       :or   {host "localhost"
              port 9030
              catalog "default_catalog"}}]
@@ -62,43 +181,52 @@
         ;; This allows us to connect and then query SHOW DATABASES to list all databases
         catalog-trimmed (when catalog (str/trim catalog))
         dbname-trimmed (when dbname (str/trim dbname))
-        
+
         db-name (cond
                   ;; Both catalog and database provided
-                  (and (not (str/blank? catalog-trimmed)) 
+                  (and (not (str/blank? catalog-trimmed))
                        (not (str/blank? dbname-trimmed)))
                   (str catalog-trimmed "." dbname-trimmed)
-                  
+
                   ;; Only catalog provided - use information_schema as connection target
                   ;; This is a system database that always exists in every catalog
                   (not (str/blank? catalog-trimmed))
                   (str catalog-trimmed ".information_schema")
-                  
+
                   ;; Fallback to default_catalog
                   :else
                   "default_catalog.information_schema")
-        
-        ;; Base JDBC spec using MariaDB driver (MySQL compatible)
-        base-spec {:classname   "org.mariadb.jdbc.Driver"
-                   :subprotocol "mysql"
-                   :subname     (str "//" host ":" port "/" db-name)
-                   :user        user
-                   :password    password
-                   ;; StarRocks-specific settings
-                   :tinyInt1isBit "false"
-                   :yearIsDateType "false"
-                   :serverTimezone "UTC"
-                   :useSSL "false"
-                   :allowPublicKeyRetrieval "true"
-                   :zeroDateTimeBehavior "convertToNull"}]
-    ;; Merge any additional options
-    (if (and additional-options (not (str/blank? additional-options)))
-      (merge base-spec
-             (into {}
-                   (for [pair (str/split additional-options #"&")
-                         :when (not (str/blank? pair))]
-                     (let [[k v] (str/split pair #"=" 2)]
-                       [(keyword k) (or v "")]))))
+
+        ssl?         (ssl-enabled? {:ssl ssl})
+        ssl-cert-pem (when (and ssl? ssl-cert (valid-pem? (str ssl-cert)))
+                       (str/trim (str ssl-cert)))
+
+        _            (maybe-log-ssl-hint ssl? ssl-cert ssl-mode additional-options)
+
+        ;; MySQL Connector/J — SSL with server certificate verification (VERIFY_CA / VERIFY_IDENTITY)
+        base-spec (cond-> {:classname   "com.mysql.cj.jdbc.Driver"
+                           :subprotocol "mysql"
+                           :subname     (str "//" host ":" port "/" db-name)
+                           :user        user
+                           :password    password
+                           ;; StarRocks-specific settings
+                           :tinyInt1isBit "false"
+                           :yearIsDateType "false"
+                           :serverTimezone "UTC"
+                           :allowPublicKeyRetrieval "true"
+                           :zeroDateTimeBehavior "convertToNull"}
+                     (not ssl?) (assoc :useSSL "false")
+                     ssl?       (merge (ssl-jdbc-spec ssl-cert-pem ssl-mode)))
+
+        addl-spec (when-let [opts (additional-options->map additional-options)]
+                    (let [opts+keys (into {}
+                                          (map (fn [[k v]] [(keyword k) v]))
+                                          opts)]
+                      (if ssl?
+                        opts+keys
+                        (without-ssl-jdbc-keys opts+keys))))]
+    (if addl-spec
+      (merge base-spec addl-spec)
       base-spec)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -380,7 +508,11 @@
       (jdbc/query spec ["SELECT 1"])
       true)
     (catch Exception e
-      (log/errorf "StarRocks connection failed: %s" (.getMessage e))
+      (let [msg (loop [ex ^Exception e, acc []]
+                  (if ex
+                    (recur (ex-cause ex) (conj acc (.getMessage ex)))
+                    (str/join " -> " (remove str/blank? acc))))]
+        (log/errorf "StarRocks connection failed: %s" msg))
       false)))
 
 (defmethod driver/humanize-connection-error-message :starrocks
@@ -399,6 +531,29 @@
       
       (re-find #"(?i)unknown catalog" msg)
       "Catalog not found. Please check the catalog name."
-      
+
+      (re-find #"(?i)insecure transport" msg)
+      (str msg " — This StarRocks instance requires SSL. Enable \"Use a secure connection (SSL)\" in Metabase.")
+
+      (re-find #"(?i)could not load system variables" msg)
+      (str msg " — JDBC driver could not read MySQL session variables from StarRocks. "
+           "Ensure SSL is enabled if required, then retry.")
+
+      (re-find #"(?i)PKIX|certificate_unknown|certpath|unable to find valid certification path" msg)
+      (str msg " — Certificate verification failed. Use SSL mode VERIFY_CA and paste the FE CA PEM chain, "
+           "or VERIFY_IDENTITY if the CA is in the JVM trust store. Internal hostnames often need VERIFY_CA, not VERIFY_IDENTITY.")
+
+      (re-find #"(?i)hostname.*not match|name mismatch|No subject alternative" msg)
+      (str msg " — Hostname does not match the server certificate. Use SSL mode VERIFY_CA with the CA PEM chain "
+           "(does not require hostname match), or connect using the hostname on the certificate.")
+
+      (re-find #"(?i)PEM KeyStore not available|PEM not found|Failed to create keystore" msg)
+      (str msg " — Invalid or unsupported certificate material. Paste a valid PEM chain (-----BEGIN CERTIFICATE-----) "
+           "and use SSL mode VERIFY_CA.")
+
+      (re-find #"(?i)ssl|tls|handshake" msg)
+      (str msg " — Ensure StarRocks FE has SSL enabled (ssl_keystore_* in fe.conf, v3.4.1+)"
+           " and that \"Use a secure connection (SSL)\" is checked in Metabase.")
+
       :else
       msg)))

--- a/src/metabase/driver/starrocks.clj
+++ b/src/metabase/driver/starrocks.clj
@@ -148,9 +148,9 @@
   (boolean (and ssl-mode (re-find #"VERIFY" ssl-mode))))
 
 (defn- default-ssl-mode
-  "Default sslMode when the form field is left empty."
-  [ssl-cert-pem]
-  (if ssl-cert-pem "VERIFY_CA" "VERIFY_IDENTITY"))
+  "Default sslMode when the form field is left empty (matches plugin default)."
+  []
+  "VERIFY_CA")
 
 (defn- ssl-jdbc-spec
   "Build JDBC SSL options from the ssl-mode form field and optional PEM trust material.
@@ -158,7 +158,7 @@
    and also checks that the certificate hostname matches the connection host."
   [ssl-cert-pem ssl-mode-from-form]
   (let [ssl-mode       (or (normalize-ssl-mode ssl-mode-from-form)
-                           (default-ssl-mode ssl-cert-pem))
+                           (default-ssl-mode))
         use-custom-ca? (and (= ssl-mode "VERIFY_CA")
                             (valid-pem? ssl-cert-pem))]
     (cond-> {:useSSL "true" :sslMode ssl-mode}
@@ -173,7 +173,7 @@
   [spec ssl-cert-pem form-ssl-mode addl-spec]
   (let [effective-mode (or (some-> (:sslMode addl-spec) normalize-ssl-mode)
                            (normalize-ssl-mode form-ssl-mode)
-                           (default-ssl-mode ssl-cert-pem))
+                           (default-ssl-mode))
         derived-spec   (ssl-jdbc-spec ssl-cert-pem effective-mode)
         user-overrides (when addl-spec (select-keys addl-spec ssl-jdbc-property-keys))]
     (-> spec
@@ -189,7 +189,7 @@
           ssl-cert?       (valid-pem? (str ssl-cert))
           form-ssl-mode   (normalize-ssl-mode ssl-mode-from-form)
           addl-ssl-mode   (some-> (:sslMode addl-opts-map) normalize-ssl-mode)
-          effective-mode  (or addl-ssl-mode form-ssl-mode (default-ssl-mode (when ssl-cert? (str ssl-cert))))]
+          effective-mode  (or addl-ssl-mode form-ssl-mode (default-ssl-mode))]
       (when (= "false" (:verifyServerCertificate addl-opts-map))
         (log/warn "StarRocks SSL: verifyServerCertificate=false disables certificate validation."))
       (when (= "REQUIRED" effective-mode)

--- a/src/metabase/driver/starrocks.clj
+++ b/src/metabase/driver/starrocks.clj
@@ -73,10 +73,32 @@
     :clientCertificateKeyStoreUrl :clientCertificateKeyStoreType :clientCertificateKeyStorePassword
     :enabledSslProtocolSuites :enabledSslCipherSuites})
 
+(def ^:private ssl-jdbc-truststore-keys
+  #{:trustCertificateKeyStoreUrl :trustCertificateKeyStoreType :trustCertificateKeyStorePassword})
+
+(def ^:private ssl-jdbc-derived-keys
+  (into #{:sslMode :verifyServerCertificate} ssl-jdbc-truststore-keys))
+
 (defn- ssl-enabled?
   "SSL is opt-in only: controlled by the Metabase \"Use a secure connection (SSL)\" checkbox."
   [{:keys [ssl]}]
   (boolean ssl))
+
+(defn- additional-opt-keyword
+  "Keywordize an additional-options key, matching SSL JDBC properties case-insensitively."
+  [k]
+  (or (some (fn [ssl-k]
+              (when (= (str/lower-case (name ssl-k))
+                       (str/lower-case k))
+                ssl-k))
+            ssl-jdbc-property-keys)
+      (keyword k)))
+
+(defn- additional-options->keyword-map
+  "Parse `additional-options` into a map with canonical keyword keys."
+  [additional-options]
+  (when-let [opts (additional-options->map additional-options)]
+    (into {} (map (fn [[k v]] [(additional-opt-keyword k) v]) opts))))
 
 (defn- without-ssl-jdbc-keys
   "Remove SSL-related keys so additional-options cannot enable SSL when the checkbox is off."
@@ -84,11 +106,13 @@
   (into {} (remove (fn [[k _]] (contains? ssl-jdbc-property-keys k)) opts-map)))
 
 (defn- valid-pem?
-  "True when `pem-content` looks like at least one PEM certificate block."
+  "True when `pem-content` contains at least one parseable PEM X.509 certificate."
   [pem-content]
   (boolean
    (and (not (str/blank? pem-content))
-        (re-find #"-----BEGIN CERTIFICATE-----" (str pem-content)))))
+        (try
+          (pos? (alength (parse-pem-certificates (str pem-content))))
+          (catch Exception _ false)))))
 
 (defn- parse-pem-certificates
   "Parse one or more PEM X.509 certificates from `pem-content`."
@@ -108,6 +132,8 @@
   [^String pem-content]
   (let [certs     (parse-pem-certificates pem-content)
         ^KeyStore ks (KeyStore/getInstance (KeyStore/getDefaultType))]
+    (when (zero? (alength certs))
+      (throw (IllegalArgumentException. "No parseable X.509 certificates in PEM content")))
     (.load ks nil nil)
     (dotimes [i (alength certs)]
       (.setCertificateEntry ks (str "ca-" i) (aget certs i)))
@@ -115,7 +141,7 @@
                               (.deleteOnExit))]
       (with-open [^FileOutputStream os (FileOutputStream. f)]
         (.store ks os (char-array "")))
-      (str "file:" (.getAbsolutePath f)))))
+      (.toString (.toURI f)))))
 
 (defn- normalize-ssl-mode
   "Normalize ssl-mode from the connection form (e.g. verify-identity -> VERIFY_IDENTITY)."
@@ -150,23 +176,36 @@
              :trustCertificateKeyStoreUrl   (jks-truststore-file-url ssl-cert-pem)
              :trustCertificateKeyStorePassword ""))))
 
+(defn- reconcile-ssl-spec
+  "Align truststore and verifyServerCertificate with the effective sslMode after merging additional options."
+  [spec ssl-cert-pem form-ssl-mode addl-spec]
+  (let [effective-mode (or (some-> (:sslMode addl-spec) normalize-ssl-mode)
+                             (normalize-ssl-mode form-ssl-mode)
+                             (default-ssl-mode ssl-cert-pem))
+        derived-spec   (ssl-jdbc-spec ssl-cert-pem effective-mode)
+        user-overrides (when addl-spec (select-keys addl-spec ssl-jdbc-property-keys))]
+    (-> spec
+        (#(reduce dissoc % ssl-jdbc-derived-keys))
+        (merge (select-keys derived-spec ssl-jdbc-derived-keys))
+        (merge user-overrides))))
+
 (defn- maybe-log-ssl-hint
   "Log SSL configuration hints when verification is enabled."
   [ssl? ssl-cert ssl-mode-from-form additional-options]
   (when ssl?
-    (let [addl-opts-map   (additional-options->map additional-options)
-          ssl-cert?       (and ssl-cert (not (str/blank? (str ssl-cert))))
+    (let [addl-opts-map   (additional-options->keyword-map additional-options)
+          ssl-cert?       (valid-pem? (str ssl-cert))
           form-ssl-mode   (normalize-ssl-mode ssl-mode-from-form)
-          addl-ssl-mode   (some-> (get addl-opts-map "sslMode") normalize-ssl-mode)
+          addl-ssl-mode   (some-> (:sslMode addl-opts-map) normalize-ssl-mode)
           effective-mode  (or addl-ssl-mode form-ssl-mode (default-ssl-mode (when ssl-cert? (str ssl-cert))))]
-      (when (= "false" (get addl-opts-map "verifyServerCertificate"))
+      (when (= "false" (:verifyServerCertificate addl-opts-map))
         (log/warn "StarRocks SSL: verifyServerCertificate=false disables certificate validation."))
       (when (= "REQUIRED" effective-mode)
         (log/warnf "StarRocks SSL: sslMode=REQUIRED encrypts but does not verify the server certificate."
                    effective-mode))
       (when (and (ssl-mode-verifies-certificate? effective-mode)
                  (not ssl-cert?)
-                 (not (contains? addl-opts-map "trustCertificateKeyStoreUrl")))
+                 (not (contains? addl-opts-map :trustCertificateKeyStoreUrl)))
         (log/infof "StarRocks SSL: sslMode=%s with JVM truststore. Paste the server CA PEM chain into 'Server SSL certificate chain' if you see PKIX / certificate_unknown errors."
                    effective-mode)))))
 
@@ -218,16 +257,13 @@
                      (not ssl?) (assoc :useSSL "false")
                      ssl?       (merge (ssl-jdbc-spec ssl-cert-pem ssl-mode)))
 
-        addl-spec (when-let [opts (additional-options->map additional-options)]
-                    (let [opts+keys (into {}
-                                          (map (fn [[k v]] [(keyword k) v]))
-                                          opts)]
-                      (if ssl?
-                        opts+keys
-                        (without-ssl-jdbc-keys opts+keys))))]
-    (if addl-spec
-      (merge base-spec addl-spec)
-      base-spec)))
+        addl-spec (when-let [opts (additional-options->keyword-map additional-options)]
+                    (if ssl?
+                      opts
+                      (without-ssl-jdbc-keys opts)))]
+    (cond-> base-spec
+      addl-spec (merge addl-spec)
+      ssl?      (#(reconcile-ssl-spec % ssl-cert-pem ssl-mode addl-spec)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Type Mappings                                                          |

--- a/src/metabase/driver/starrocks.clj
+++ b/src/metabase/driver/starrocks.clj
@@ -161,8 +161,6 @@
                            (default-ssl-mode ssl-cert-pem))
         use-custom-ca? (and (= ssl-mode "VERIFY_CA")
                             (valid-pem? ssl-cert-pem))]
-    (when (and (= ssl-mode "VERIFY_CA") ssl-cert-pem (not (valid-pem? ssl-cert-pem)))
-      (log/warn "StarRocks SSL: ssl-cert is set but does not contain a valid PEM certificate; using JVM truststore only."))
     (cond-> {:useSSL "true" :sslMode ssl-mode}
       (= ssl-mode "VERIFY_IDENTITY") (assoc :verifyServerCertificate "true")
       use-custom-ca?
@@ -196,8 +194,12 @@
         (log/warn "StarRocks SSL: verifyServerCertificate=false disables certificate validation."))
       (when (= "REQUIRED" effective-mode)
         (log/warn "StarRocks SSL: sslMode=REQUIRED encrypts but does not verify the server certificate."))
-      (when (and (ssl-mode-verifies-certificate? effective-mode)
+      (when (and (not (str/blank? (str ssl-cert)))
                  (not ssl-cert?)
+                 (ssl-mode-verifies-certificate? effective-mode))
+        (log/warn "StarRocks SSL: ssl-cert is set but does not contain a valid PEM certificate; using JVM truststore only."))
+      (when (and (ssl-mode-verifies-certificate? effective-mode)
+                 (str/blank? (str ssl-cert))
                  (not (contains? addl-opts-map :trustCertificateKeyStoreUrl)))
         (log/infof "StarRocks SSL: sslMode=%s with JVM truststore. Paste the server CA PEM chain into 'Server SSL certificate chain' if you see PKIX / certificate_unknown errors."
                    effective-mode)))))

--- a/src/metabase/driver/starrocks.clj
+++ b/src/metabase/driver/starrocks.clj
@@ -73,12 +73,6 @@
     :clientCertificateKeyStoreUrl :clientCertificateKeyStoreType :clientCertificateKeyStorePassword
     :enabledSslProtocolSuites :enabledSslCipherSuites})
 
-(def ^:private ssl-jdbc-truststore-keys
-  #{:trustCertificateKeyStoreUrl :trustCertificateKeyStoreType :trustCertificateKeyStorePassword})
-
-(def ^:private ssl-jdbc-derived-keys
-  (into #{:sslMode :verifyServerCertificate} ssl-jdbc-truststore-keys))
-
 (defn- ssl-enabled?
   "SSL is opt-in only: controlled by the Metabase \"Use a secure connection (SSL)\" checkbox."
   [{:keys [ssl]}]
@@ -176,17 +170,17 @@
              :trustCertificateKeyStoreUrl   (jks-truststore-file-url ssl-cert-pem)
              :trustCertificateKeyStorePassword ""))))
 
-(defn- reconcile-ssl-spec
-  "Align truststore and verifyServerCertificate with the effective sslMode after merging additional options."
+(defn- apply-ssl-spec
+  "Apply SSL JDBC properties once, honoring form settings, additional-options overrides, and sslMode-dependent keys."
   [spec ssl-cert-pem form-ssl-mode addl-spec]
   (let [effective-mode (or (some-> (:sslMode addl-spec) normalize-ssl-mode)
-                             (normalize-ssl-mode form-ssl-mode)
-                             (default-ssl-mode ssl-cert-pem))
+                           (normalize-ssl-mode form-ssl-mode)
+                           (default-ssl-mode ssl-cert-pem))
         derived-spec   (ssl-jdbc-spec ssl-cert-pem effective-mode)
         user-overrides (when addl-spec (select-keys addl-spec ssl-jdbc-property-keys))]
     (-> spec
-        (#(reduce dissoc % ssl-jdbc-derived-keys))
-        (merge (select-keys derived-spec ssl-jdbc-derived-keys))
+        (#(reduce dissoc % ssl-jdbc-property-keys))
+        (merge derived-spec)
         (merge user-overrides))))
 
 (defn- maybe-log-ssl-hint
@@ -201,8 +195,7 @@
       (when (= "false" (:verifyServerCertificate addl-opts-map))
         (log/warn "StarRocks SSL: verifyServerCertificate=false disables certificate validation."))
       (when (= "REQUIRED" effective-mode)
-        (log/warnf "StarRocks SSL: sslMode=REQUIRED encrypts but does not verify the server certificate."
-                   effective-mode))
+        (log/warn "StarRocks SSL: sslMode=REQUIRED encrypts but does not verify the server certificate."))
       (when (and (ssl-mode-verifies-certificate? effective-mode)
                  (not ssl-cert?)
                  (not (contains? addl-opts-map :trustCertificateKeyStoreUrl)))
@@ -254,8 +247,7 @@
                            :serverTimezone "UTC"
                            :allowPublicKeyRetrieval "true"
                            :zeroDateTimeBehavior "convertToNull"}
-                     (not ssl?) (assoc :useSSL "false")
-                     ssl?       (merge (ssl-jdbc-spec ssl-cert-pem ssl-mode)))
+                     (not ssl?) (assoc :useSSL "false"))
 
         addl-spec (when-let [opts (additional-options->keyword-map additional-options)]
                     (if ssl?
@@ -263,7 +255,7 @@
                       (without-ssl-jdbc-keys opts)))]
     (cond-> base-spec
       addl-spec (merge addl-spec)
-      ssl?      (#(reconcile-ssl-spec % ssl-cert-pem ssl-mode addl-spec)))))
+      ssl?      (#(apply-ssl-spec % ssl-cert-pem ssl-mode addl-spec)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Type Mappings                                                          |


### PR DESCRIPTION
## Summary

- Add opt-in SSL for StarRocks MySQL protocol connections (off by default; no impact when unchecked).
- Switch JDBC driver from MariaDB to **MySQL Connector/J 8.0.33** (aligned with [StarRocks SSL documentation](https://docs.starrocks.io/docs/administration/user_privs/ssl_authentication/)).
- Connection form: **SSL mode** dropdown with three levels — `VERIFY_CA` (default), `VERIFY_IDENTITY`, `REQUIRED`.
- **Server SSL certificate chain**: paste PEM CA/chain; driver builds a JKS truststore for `VERIFY_CA`.
- Ignore SSL-related keys in additional JDBC options when SSL is disabled (prevents accidental `useSSL=true` overrides).
- Improve `humanize-connection-error-message` for PKIX, hostname mismatch, insecure transport, and PEM errors.
- Bump plugin version to **1.1.0**.

## Motivation

Managed StarRocks instances (e.g. Aliyun) often require TLS on port 9030 (`Connections using insecure transport are prohibited`). Security policies typically require certificate verification rather than encrypt-only modes.

## Test plan

- [x] Build uber JAR: `clojure -T:build uber`
- [x] Deploy to Metabase and verify driver loads (`Registered driver :starrocks`)
- [x] `REQUIRED` connects when FE mandates TLS (encrypt only)
- [x] `VERIFY_CA` + pasted CA PEM connects successfully
- [ ] `VERIFY_IDENTITY` with public CA and matching certificate hostname
- [x] SSL off: plain connections unchanged (`useSSL=false`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swapping the JDBC driver and changing default TLS behavior when SSL is enabled can affect all new encrypted connections; misconfigured trust or modes could break connects to TLS-mandatory clusters until PEM/mode are correct.
> 
> **Overview**
> Adds **opt-in TLS** for StarRocks MySQL-protocol connections (off by default) and bumps the plugin to **1.1.0**.
> 
> The connection UI gains SSL checkbox, **SSL mode** (`VERIFY_CA`, `VERIFY_IDENTITY`, `REQUIRED`), and a PEM **server certificate chain** field. JDBC moves from MariaDB to **MySQL Connector/J 8.0.33**; `connection-details->spec` maps form settings to `useSSL` / `sslMode`, builds a temp **JKS truststore** from PEM for `VERIFY_CA`, and strips or merges SSL keys from additional JDBC options so SSL cannot be turned on when the checkbox is off. Connection failures now surface clearer guidance for insecure transport, PKIX, hostname mismatch, and PEM issues. README documents SSL setup and troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f19812d13ed14d4b03b30e7a288c756cbb4c898a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->