### PR TITLE
chore(ci): add zizmor GitHub Actions security audit + harden release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,42 +14,35 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Get version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Install Clojure CLI
-        uses: DeLaGuardo/setup-clojure@12.5
+        uses: DeLaGuardo/setup-clojure@bc7570e912b028bbcc22f457adec7fdf98e2f4ed # 12.5
         with:
           cli: latest
-
-      - name: Cache Clojure dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.m2/repository
-            ~/.gitlibs
-            ~/.clojure/.cpcache
-          key: ${{ runner.os }}-clojure-${{ hashFiles('**/deps.edn') }}
-          restore-keys: |
-            ${{ runner.os }}-clojure-
 
       - name: Build JAR
         run: clojure -T:build uber
 
       - name: Rename JAR with version
-        run: mv target/starrocks.metabase-driver.jar target/starrocks.metabase-driver-${{ steps.version.outputs.VERSION }}.jar
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: mv target/starrocks.metabase-driver.jar "target/starrocks.metabase-driver-${VERSION}.jar"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: target/starrocks.metabase-driver-${{ steps.version.outputs.VERSION }}.jar
           generate_release_notes: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,42 @@
+name: GitHub Actions Security (zizmor)
+
+# Audits the repository's GitHub Actions workflows for security issues
+# (script/template injection, credential persistence, unpinned actions,
+# cache poisoning, etc.) using https://zizmor.sh. Runs on every PR and on
+# pushes to main so untrusted contributions can't introduce workflow
+# vulnerabilities unnoticed. Findings fail the build and are surfaced as
+# inline annotations on the PR diff.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/zizmor.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/zizmor.yml'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Audit workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # Surface findings as inline PR annotations and fail the build on any
+          # finding. Annotations mode (instead of advanced-security/SARIF) needs
+          # no `security-events: write`, so it works on pull requests from forks.
+          advanced-security: false
+          annotations: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,14 @@
+# zizmor configuration — https://docs.zizmor.sh/configuration/
+#
+# Findings are gated by the workflow in .github/workflows/zizmor.yml, which
+# fails the build on any reported finding. Use the `ignore` lists below to
+# document intentional, reviewed exceptions so they don't block PRs.
+
+rules:
+  # `superfluous-actions` suggests replacing softprops/action-gh-release with a
+  # `gh release` script step. We intentionally keep the action: it handles
+  # release-note generation and asset uploads cleanly and is pinned to a commit
+  # SHA. This is a style preference, not a security issue.
+  superfluous-actions:
+    ignore:
+      - release.yml


### PR DESCRIPTION
## What

Adds [zizmor](https://zizmor.sh) — a static analysis tool for GitHub Actions workflows — so open-source contributions can't introduce workflow security issues unnoticed, plus hardens the existing release workflow against the issues zizmor flagged.

## Why

This is a public repo that takes fork PRs. GitHub Actions workflows are a common attack surface (script/template injection, credential persistence, unpinned/​compromised actions, cache poisoning). A CI gate keeps that surface safe automatically.

## Changes

**New: `.github/workflows/zizmor.yml`**
- Audits all workflows on every PR and push to `main` (path-filtered to `.github/`).
- **Fails the build on any finding** — blocks PRs that introduce workflow vulnerabilities.
- Uses **annotations mode** (inline findings on the PR diff) rather than SARIF/code-scanning upload, because fork PRs don't get `security-events: write` — SARIF upload would turn even clean fork PRs red. Annotations need only `contents: read`.
- Least-privilege: top-level `permissions: {}`, `contents: read` on the job.

**New: `.github/zizmor.yml`**
- Ignores one rule (`superfluous-actions` on `release.yml`) with a written reason — it's a style preference (use `gh release` over the `softprops` action), not a security issue.

**Hardened: `.github/workflows/release.yml`**
- `template-injection` — moved tag-derived `VERSION` into an `env:` var instead of interpolating into a `run:` block (a crafted tag could otherwise inject shell).
- `artipacked` — `persist-credentials: false` on checkout.
- `unpinned-uses` — pinned all 5 actions to commit SHAs (with version comments; Dependabot can still bump them).
- `cache-poisoning` — removed `actions/cache` from the tag-triggered release build, since a poisoned cache could taint the released JAR. ⚠️ Behavior change: release builds no longer cache Clojure deps (negligible — releases are infrequent).

## Verification

Ran locally with the exact flags the CI action uses — exits **0** on both workflows:

```
zizmor --persona=regular --format=github -- .github/workflows/
```