### PR TITLE
Fix StarRocks LIKE escaping and native SQL prettify

### DIFF
--- a/src/metabase/driver/starrocks.clj
+++ b/src/metabase/driver/starrocks.clj
@@ -247,6 +247,21 @@
 ;; Use MySQL-style quoting since StarRocks is MySQL-compatible
 (defmethod sql.qp/quote-style :starrocks [_] :mysql)
 
+;; Metabase 0.59+ adds ESCAPE '\' for literal LIKE patterns used by
+;; :contains/:starts-with/:ends-with filters. StarRocks does not parse explicit
+;; ESCAPE syntax here, while backslash escaping is already treated as built in.
+(defmethod sql.qp/transform-literal-like-pattern-honeysql :starrocks
+  [_driver like-rhs-honeysql]
+  like-rhs-honeysql)
+
+(prefer-method sql.qp/transform-literal-like-pattern-honeysql :starrocks :sql)
+
+;; /api/dataset/native prettification corrupts MySQL-style backtick identifiers
+;; for StarRocks, e.g. `silver`.`table`.`field` -> ` silver `.` table `.` field `.
+(defmethod driver/prettify-native-form :starrocks
+  [_driver native-form]
+  native-form)
+
 ;; Date/time handling
 (defmethod sql.qp/unix-timestamp->honeysql [:starrocks :seconds]
   [_ _ expr]


### PR DESCRIPTION
This fixes two StarRocks compatibility issues observed on Metabase 0.61+/1.61+.

1. Field Filters with widget type "String contains" fail because Metabase generates explicit `LIKE ... ESCAPE '\'`, while StarRocks does not parse that syntax. This overrides `transform-literal-like-pattern-honeysql` for `:starrocks` so the generated LIKE pattern is left unchanged.
(started from metabase v59)

2. Query Builder -> Native SQL conversion corrupts MySQL-style backtick identifiers during prettification, e.g. `silver`.`table`.`field` becomes ` silver `.` table `.` field `. This disables native SQL prettification for StarRocks.

Validation:
- Built successfully with `clojure -T:build uber`
- Verified the generated jar contains both driver overrides

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Driver-only query/display overrides for StarRocks with no auth or shared core logic changes.
> 
> **Overview**
> Adds two **StarRocks** driver overrides for Metabase 0.59+/0.61+ SQL generation behavior.
> 
> **String filters** (`contains` / `starts-with` / `ends-with`): the default SQL path now wraps literal `LIKE` patterns with explicit `ESCAPE '\'`, which StarRocks rejects. StarRocks is wired to leave the honeysql pattern unchanged (with `prefer-method` toward `:sql`), relying on its built-in backslash escaping.
> 
> **Native SQL display**: prettification for `/api/dataset/native` is turned off for StarRocks so MySQL-style backtick identifiers (e.g. `` `catalog`.`table`.`field` ``) are not rewritten with spurious spaces inside the quotes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaca2f632db38d8bdf746827fc8a221125b5aa34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->