### PR TITLE
fix: remove describe-table-fks to restore Metabase 0.63 compatibility

### DIFF
--- a/src/metabase/driver/starrocks.clj
+++ b/src/metabase/driver/starrocks.clj
@@ -235,10 +235,9 @@
                                (inc idx)))
                       (set fields)))})))))
 
-;;; The StarRocks JDBC doesn't support foreign keys
-(defmethod driver/describe-table-fks :starrocks
-  [_driver _database _table]
-  nil)
+;;; StarRocks doesn't support foreign keys. This is already declared above via
+;;; `:metadata/key-constraints false`, which is what Metabase gates FK metadata
+;;; fetching on, so no `describe-fks` implementation is needed here.
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                          Query Processing                                                       |


### PR DESCRIPTION
## Problem

After upgrading Metabase to 0.63.x, every GUI/MBQL question against a StarRocks database fails with:

```
Getting syntax error at line 2, column 13. Detail message: Unexpected input
'"my_table"', the most similar input is {a legal identifier}.
```

Native SQL questions still work, so the symptom looks like "all my GUI questions broke" rather than a driver problem. Metabase logs the real cause:

```
ERROR driver.util :: Failed to connect to Database:
Syntax error compiling at (metabase/driver/starrocks.clj:239:1).
```

## Root cause

Metabase 0.63.0 **removed `driver/describe-table-fks`** (replaced by `driver/describe-fks`) — see the [driver changelog](https://www.metabase.com/docs/latest/developers-guide/driver-changelog).

`src/metabase/driver/starrocks.clj:239` still defines it. Clojure evaluates a namespace's top-level forms in order, so referencing the now-missing var aborts the load of `metabase.driver.starrocks` at that form. Every `defmethod` after line 239 is then **silently never registered** — including, nine lines later:

```clojure
(defmethod sql.qp/quote-style :starrocks [_] :mysql)   ; line 248
```

Identifier quoting falls back to the `:sql-jdbc` default of `:ansi`, so MBQL compiles to:

```sql
SELECT "dws"."t"."col" FROM "dws"."t"
```

which StarRocks cannot parse. Everything below line 239 is lost the same way — `sql.qp/date` (all bucketing), `datetime-diff`, temporal casts, LIKE escaping, `prettify-native-form`, `can-connect?`.

The forms *before* line 239 do load, which is why `connection-details->spec` still works and native SQL still runs — hence the confusing partial failure.

## Why removing it is safe

The method was never reachable on any Metabase version. Metabase only fetches FK metadata when the driver supports `:metadata/key-constraints`:

```clojure
;; metabase/sync/fetch_metadata.clj
(when (driver.u/supports? driver :metadata/key-constraints database)
  (driver/describe-fks ...))
```

and this driver already declares that `false` (plus `:foreign-keys false`) in the feature map at the top of the file. So deleting it is a no-op on every supported version, and restores namespace loading on 0.63+. No `describe-fks` implementation is needed.

## Backward compatibility

Safe on every version the driver supports (v0.50+), for three independent reasons.

**1. It was never invoked.** 0.57 and 0.63 gate FK fetching identically:

```clojure
;; metabase/sync/fetch_metadata.clj -- same in release-x.57.x and master
(when (driver.u/supports? driver :metadata/key-constraints database)
  ...)
```

and this driver declares `:metadata/key-constraints false` (plus `:foreign-keys false`).

**2. It has been deprecated since 0.49.0.** Its own docstring scopes it to *"drivers that support `:metadata/key-constraints` but not `:describe-fks`"* — StarRocks supports neither:

```clojure
(defmulti describe-table-fks
  ...
  {:added "0.32.0" :deprecated "0.49.0" :arglists '([driver database table])}
```

**3. The core default is identical to the removed override.** In 0.57:

```clojure
(defmethod describe-table-fks ::driver [_ _ _]
  nil)
```

The driver's override also returned `nil`, so even if it were somehow reached, behaviour is unchanged.

## Verification

Tested on **Metabase v0.63.2.2** against a live StarRocks cluster.

Before (unpatched `main`, v1.0.4) — the database cannot even be added:

```
Syntax error compiling at (metabase/driver/starrocks.clj:239:1).
```

After, all compile with backticks and execute successfully:

| Query | Compiled SQL | Result |
|---|---|---|
| plain select | `` FROM `ads`.`tbl` `` | 3 rows |
| count aggregation | `` SELECT COUNT(*) AS `count` `` | 1,858,476 |
| breakout by month | `` DATE_TRUNC('month', `ads`.`tbl`.`start_time`) `` | 5 rows |
| breakout by day | `` DATE_TRUNC('day', ...) `` | 5 rows |
| `contains` filter | LIKE with escaping | ok |

Also reproduced and re-verified against a MySQL stand-in, since the driver's metadata path (`SHOW DATABASES` / `SHOW TABLES FROM` / `DESCRIBE`) is MySQL-compatible.

Note this affects **v1.0.2 and v1.0.4 identically** — PR #9's changes all land after line 248, so upgrading the driver does not help.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletes unreachable FK metadata code (already gated off by `:metadata/key-constraints false`); restores driver load and query compilation without changing runtime FK behavior.
> 
> **Overview**
> **Removes the obsolete `driver/describe-table-fks` multimethod** so `metabase.driver.starrocks` loads on Metabase **0.63+**, where that API was removed in favor of `describe-fks`.
> 
> On 0.63, referencing the missing var aborted namespace evaluation, so later registrations (notably **`sql.qp/quote-style` → `:mysql`**) never ran and MBQL compiled with ANSI double-quoted identifiers that StarRocks rejects. A short comment notes that **`:metadata/key-constraints false`** already disables FK metadata, so no `describe-fks` override is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43457c560694a00adb4a1e56152127b5e83135db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->